### PR TITLE
Document remote MCP troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ Bu proje, çeşitli Türk hukuk kaynaklarına (Yargıtay, Danıştay, Emsal Kara
 
 > 💡 **İpucu:** Remote MCP sayesinde Python, uv veya herhangi bir kurulum yapmadan doğrudan Claude Desktop üzerinden Türk hukuk kaynaklarına erişebilirsiniz!
 
+### Remote MCP Sorun Giderme
+
+`https://yargimcp.surucu.dev/mcp` bir web sayfası değil, Streamable HTTP MCP uç noktasıdır. Tarayıcıda açınca veya düz `curl` ile GET isteği atınca `406 Not Acceptable` ve `Client must accept text/event-stream` benzeri bir yanıt görmek normaldir; bu, sunucunun kapalı olduğu anlamına gelmez. MCP istemcisi `Accept: application/json, text/event-stream` başlığıyla JSON-RPC isteği göndermelidir.
+
+Hızlı sağlık kontrolü için tarayıcıda şu adresleri açabilirsiniz:
+
+- `https://yargimcp.surucu.dev/health` — servis sağlık durumu
+
+Claude.ai veya başka bir istemci "araç yok" gibi davranırsa:
+
+1. Connector'ı kaldırıp yeniden ekleyin.
+2. URL olarak önce `https://yargimcp.surucu.dev/mcp` deneyin; istemciniz yönlendirmeleri takip etmiyorsa `https://yargimcp.surucu.dev/mcp/` deneyin.
+3. Eski `https://yargimcp.fastmcp.app/mcp` adresinin istemci ayarlarında veya önbellekte kalmadığından emin olun.
+4. İstemcinin remote/Streamable HTTP MCP desteklediğini ve `text/event-stream` kabul ettiğini kontrol edin.
+
 ---
 
 ![örnek](./ornek.png)


### PR DESCRIPTION
## Summary
- document that `/mcp` is a Streamable HTTP MCP endpoint, not a browser page
- explain why plain browser/curl GET can return `406 Not Acceptable: Client must accept text/event-stream`
- add a short connector checklist for Claude.ai/no-tools cases and stale endpoint cache

## Verification
- `git diff --check`
- `curl -sS https://yargimcp.surucu.dev/health`
- `curl -i -sS https://yargimcp.surucu.dev/mcp | head -20`

Refs #25